### PR TITLE
Fix upper/lowercasing of unit letters

### DIFF
--- a/src/carconnectivity/units.py
+++ b/src/carconnectivity/units.py
@@ -74,7 +74,7 @@ class Power(GenericUnit,):
     """
     A class representing a unit of measurement for power.
     """
-    KW = 'KW'
+    KW = 'kW'
     W = 'W'
     INVALID = 'invalid'
     UNKNOWN = 'unknown power unit'
@@ -84,8 +84,8 @@ class Energy(GenericUnit,):
     """
     A class representing a unit of measurement for energy.
     """
-    KWH = 'KWH'
-    WH = 'WH'
+    KWH = 'kWh'
+    WH = 'Wh'
     INVALID = 'invalid'
     UNKNOWN = 'unknown energy unit'
 
@@ -103,8 +103,8 @@ class Speed(GenericUnit,):
     """
     A class representing a unit of measurement for speed.
     """
-    KMH = 'Km/h'
-    MPH = 'Mph'
+    KMH = 'km/h'
+    MPH = 'mph'
     INVALID = 'invalid'
     UNKNOWN = 'unknown speed unit'
 


### PR DESCRIPTION
I stumbled upon warnings about change of Units in Home-Assistant after switching to this integration. Root-cause seems to be the unit-definitions in this file. It contains some units which are probably typos of the more correct/common abbreveations. See for example: https://en.wikipedia.org/wiki/Kilowatt-hour

