### PR TITLE
Fix check for duplicates when adding _on_set_hooks

### DIFF
--- a/src/carconnectivity/attributes.py
+++ b/src/carconnectivity/attributes.py
@@ -141,7 +141,7 @@ class GenericAttribute(Observable, Generic[T, U]):  # pylint: disable=too-many-i
         Returns:
             None
         """
-        if hook not in self._on_set_hooks:
+        if (hook, early_hook) not in self._on_set_hooks:
             self._on_set_hooks.append((hook, early_hook))
 
     def _execute_on_set_hook(self, new_value: Optional[T], early_hook=False) -> Optional[T]:


### PR DESCRIPTION
This fixes the issue I opened on the wrong project: https://github.com/tillsteinbach/CarConnectivity-plugin-mqtt/issues/72

In that issue I described how after several data refreshes if I make a change to target_level (but any attribute is affected) then it results in duplicate requests to the API.

Now I understand that it is because of the wrong check for duplicate hook during add which resulted in the same hook being added to an attribute everytime vehicle data was fetched. When a change was made by writing a message to an attribute_writetopic it resulted in the same value change being processed N times.