### PR TITLE
Add attributes and units for trip data

### DIFF
--- a/src/carconnectivity/attributes.py
+++ b/src/carconnectivity/attributes.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone, timedelta
 
 from pytimeparse import parse
 
-from carconnectivity.units import GenericUnit, Length, Level, Temperature, Speed, Power, Current, Energy
+from carconnectivity.units import GenericUnit, Length, Level, Temperature, Speed, Power, Current, Energy, Minutes
 from carconnectivity.observable import Observable
 from carconnectivity.json_util import ExtendedWithNullEncoder
 
@@ -788,6 +788,14 @@ class DurationAttribute(GenericAttribute[timedelta, None]):
                 raise ValueError(f'Value {new_value}{self.unit.value if self.unit is not None else ""} '
                                  f'is above maximum {self.maximum}{self.unit.value if self.unit is not None else ""}')
         GenericAttribute.value.fset(self, new_value)
+
+class MinutesAttribute(GenericAttribute[Minutes, None]):
+    """
+    A class used to represent a Duration in minutes.
+    """
+    def __init__(self, name: str, parent: GenericObject, value: Optional[Minutes] = None, unit:  Minutes = Minutes.MIN,
+                 maximum: Optional[Minutes] = None, minimum: Optional[Minutes] = None, tags: Optional[Set[str]] = None) -> None:
+        super().__init__(name=name, parent=parent, value=value, value_type=Minutes, unit=unit, tags=tags)
 
 
 class RangeAttribute(FloatAttribute[Length]):

--- a/src/carconnectivity/drive.py
+++ b/src/carconnectivity/drive.py
@@ -11,8 +11,8 @@ from typing import TYPE_CHECKING
 from enum import Enum
 
 from carconnectivity.objects import GenericObject
-from carconnectivity.attributes import RangeAttribute, LevelAttribute, EnumAttribute
-from carconnectivity.units import Length
+from carconnectivity.attributes import RangeAttribute, LevelAttribute, EnumAttribute, EnergyAttribute, SpeedAttribute, MinutesAttribute
+from carconnectivity.units import Length, Speed, FuelConsumption, ElectricConsumption, Minutes
 from carconnectivity.battery import Battery
 
 if TYPE_CHECKING:
@@ -28,6 +28,9 @@ class Drives(GenericObject):
         super().__init__(object_id='drives', parent=vehicle)
         self.total_range: RangeAttribute = RangeAttribute(name="total_range", parent=self, value=None, unit=Length.UNKNOWN, minimum=0, precision=0.1,
                                                           tags={'carconnectivity'})
+        self.last_trip_distance: RangeAttribute = RangeAttribute(name="last_trip_distance", parent=self, value=None, unit=Length.KM, minimum=0, tags={'carconnectivity'}) 
+        self.last_trip_average_speed: SpeedAttribute = SpeedAttribute(name="last_trip_averageSpeed", parent=self, value=None, unit=Speed.KMH, minimum=0, tags={'carconnectivity'}) 
+        self.last_trip_duration: MinutesAttribute = MinutesAttribute(name="last_trip_duration", parent=self, value=None, unit=Minutes.MIN, minimum=0, tags={'carconnectivity'}) 
         self.drives: Dict[str, GenericDrive] = {}
 
     def add_drive(self, drive: GenericDrive) -> None:
@@ -78,6 +81,7 @@ class ElectricDrive(GenericDrive):
     def __init__(self, drive_id: str, drives: Drives) -> None:
         super().__init__(drive_id=drive_id, drives=drives)
         self.battery: Battery = Battery(drive=self)
+        self.last_trip_electric_consumption: EnergyAttribute = EnergyAttribute(name="last_trip_electricConsumption", parent=self, value=None, unit=ElectricConsumption.KWH, tags={'carconnectivity'}) 
 
 
 class CombustionDrive(GenericDrive):
@@ -86,6 +90,7 @@ class CombustionDrive(GenericDrive):
     """
     def __init__(self, drive_id: str, drives: Drives) -> None:
         super().__init__(drive_id=drive_id, drives=drives)
+        self.last_trip_fuel_consumption: EnergyAttribute = EnergyAttribute(name="last_trip_fuelConsumption", parent=self, value=None, unit=FuelConsumption.L, minimum=0, tags={'carconnectivity'}) 
 
 
 class DieselDrive(CombustionDrive):

--- a/src/carconnectivity/units.py
+++ b/src/carconnectivity/units.py
@@ -123,3 +123,27 @@ class Heading(GenericUnit,):
     """
     DEGREE = '°'
     UNKNOWN = 'unknown headinf unit'
+
+class FuelConsumption(GenericUnit,):
+    """
+    A class representing a unit of measurement for fuel consumption.
+    """
+    L = 'L/100km'
+    INVALID = 'invalid'
+    UNKNOWN = 'unknown fuel consumption unit'
+
+class ElectricConsumption(GenericUnit,):
+    """
+    A class representing a unit of measurement for electric energy consumption.
+    """
+    KWH = 'kWh/100km'
+    INVALID = 'invalid'
+    UNKNOWN = 'unknown electric energy consumption unit'
+
+class Minutes(GenericUnit,):
+    """
+    A class representing a unit of measurement for duration in minutes.
+    """
+    MIN = 'min'
+    INVALID = 'invalid'
+    UNKNOWN = 'unknown duration unit'


### PR DESCRIPTION
I want to have access to the last trip data from my car. This PR adds the Attributes and units required for displaying trip data.
Following trip data entities will be created via the connector (which will be following repo https://github.com/MasterTim17/CarConnectivity-connector-seatcupra )

last_trip_distance
last_trip_average_speed
last_trip_duration
last_trip_electric_consumption
last_trip_fuel_consumption

Solves https://github.com/tillsteinbach/CarConnectivity-connector-seatcupra/issues/22