### PR TITLE
feat(drive): add oil_level attribute to CombustionDrive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-- No unreleased changes so far
+### Added
+- Add `oil_level` attribute to `CombustionDrive` to expose engine oil level (percentage)
 
 ## [0.11.9] - 2026-04-24
 ### Added

--- a/src/carconnectivity/drive.py
+++ b/src/carconnectivity/drive.py
@@ -158,6 +158,8 @@ class CombustionDrive(GenericDrive):
                                                                               unit=FuelConsumption.UNKNOWN,
                                                                               minimum=0, precision=0.1, tags={'carconnectivity'},
                                                                               initialization=self.get_initialization('consumption'))
+        self.oil_level: LevelAttribute = LevelAttribute(name="oil_level", parent=self, value=None, minimum=0, precision=0.1,
+                                                        tags={'carconnectivity'}, initialization=self.get_initialization('oil_level'))
 
         self.range.add_observer(self.__on_range_or_level_change, Observable.ObserverEvent.UPDATED_NEW_MEASUREMENT,
                                 priority=Observable.ObserverPriority.INTERNAL_HIGH, on_transaction_end=True)


### PR DESCRIPTION
## Summary

Adds an `oil_level` attribute (engine oil level, percentage) to `CombustionDrive`.

## Motivation

Several VW Group brands expose the engine oil level, and the official
`CarConnectivity-connector-volkswagen` already **requests** the `oilLevel`
job from the API — but currently has nowhere to store it, so the value is
fetched and discarded. The VW EU Data Act portal also reports a real oil level
(`oil_level_actual_level`, e.g. `87.5`). There is no native attribute for it
today, so connectors can only log it as an unmapped sensor.

## Design / placement (genericity)

Engine oil is common to **every** internal-combustion engine (petrol, diesel,
CNG, LPG), so the attribute belongs on `CombustionDrive`:

- one level **above** the diesel-only `adblue_*` attributes (which stay on
  `DieselDrive`),
- alongside `fuel_tank`, the other combustion-wide consumable,
- inherited automatically by `DieselDrive`,
- **not** present on `ElectricDrive` (a pure EV has no engine oil).

It mirrors the existing `adblue_level` exactly: a `LevelAttribute` (percentage),
`minimum=0`, `precision=0.1`, `tags={'carconnectivity'}`, with the standard
`initialization` hook. No new attribute type or unit is introduced.

This keeps oil **level** (a live fluid reading on the drive) cleanly separate
from oil **service interval** (`maintenance.oil_service_due_*`), the same split
already used for AdBlue.

## No regression

Purely additive: a new attribute defaulting to `None`. No existing attribute or
behaviour changes. Verified that `CombustionDrive`/`DieselDrive` gain `oil_level`,
`ElectricDrive` does not, the value defaults to `None`, and existing combustion
attributes (`fuel_tank`, `consumption`, `range`, `level`) are intact.

## Follow-ups (separate PRs)

Connectors can then map their oil level onto `combustion_drive.oil_level`
(VW, Škoda, SEAT/Cupra, and the EU Data Act connector).

## Related PRs (oil-level feature set)
- Core: tillsteinbach/CarConnectivity#161 — add `oil_level` to `CombustionDrive`
- Connector: mikrohard/CarConnectivity-connector-vw-eu-data-act#17 — map `oil_level_actual_level` → `drive.oil_level`
- HA plugin: tillsteinbach/CarConnectivity-plugin-mqtt_homeassistant#58 — publish the Home Assistant discovery entity