### PR TITLE
feat(vehicle): add parking_brake attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-- No unreleased changes so far
+### Added
+- Add `parking_brake` attribute to vehicles (engaged / released)
 
 ## [0.11.9] - 2026-04-24
 ### Added

--- a/src/carconnectivity/vehicle.py
+++ b/src/carconnectivity/vehicle.py
@@ -11,7 +11,7 @@ from enum import Enum
 
 from carconnectivity.interfaces import IGenericVehicle
 from carconnectivity.objects import GenericObject
-from carconnectivity.attributes import StringAttribute, EnumAttribute, RangeAttribute, TemperatureAttribute, IntegerAttribute
+from carconnectivity.attributes import StringAttribute, EnumAttribute, RangeAttribute, TemperatureAttribute, IntegerAttribute, BooleanAttribute
 from carconnectivity.doors import Doors
 from carconnectivity.windows import Windows
 from carconnectivity.lights import Lights
@@ -80,6 +80,8 @@ class GenericVehicle(GenericObject, IGenericVehicle):  # pylint: disable=too-man
             self.odometer.parent = self
             self.state: EnumAttribute[GenericVehicle.State] = origin.state
             self.state.parent = self
+            self.parking_brake: BooleanAttribute = origin.parking_brake
+            self.parking_brake.parent = self
             self.connection_state: EnumAttribute[GenericVehicle.ConnectionState] = origin.connection_state
             self.connection_state.parent = self
             self.drives: Drives = origin.drives
@@ -134,6 +136,8 @@ class GenericVehicle(GenericObject, IGenericVehicle):  # pylint: disable=too-man
                                                            tags={'carconnectivity'}, initialization=self.get_initialization('odometer'))
             self.state: EnumAttribute[GenericVehicle.State] = EnumAttribute("state", parent=self, tags={'carconnectivity'}, value_type=GenericVehicle.State,
                                                                             initialization=self.get_initialization('state'))
+            self.parking_brake: BooleanAttribute = BooleanAttribute("parking_brake", parent=self, tags={'carconnectivity'},
+                                                                    initialization=self.get_initialization('parking_brake'))
             self.connection_state: EnumAttribute[GenericVehicle.ConnectionState] = EnumAttribute("connection_state", parent=self, tags={'carconnectivity'},
                                                                                                  value_type=GenericVehicle.ConnectionState,
                                                                                                  initialization=self.get_initialization('connection_state'))


### PR DESCRIPTION
## Summary

Adds a generic `parking_brake` attribute to `GenericVehicle`
(`True` = engaged, `False` = released, `None` = unknown).

## Design

- A `BooleanAttribute` on `GenericVehicle`, next to `state` — the parking brake
  is a vehicle-level state, not tied to a drive, and applies to every brand.
- Preserved across vehicle promotion (e.g. to Electric/Hybrid), exactly like
  `state`.
- Uses the existing `BooleanAttribute` type (as in `charging.auto_unlock`,
  climatization settings) — no new type or enum.

## No regression

Purely additive, defaulting to `None`; no existing attribute or behaviour
changes. Verified the attribute is present on a vehicle, settable, and preserved
through promotion to a HybridVehicle.

## Follow-ups (separate PRs)

Connectors can map their parking-brake field onto `vehicle.parking_brake`
(e.g. the VW EU Data Act connector exposes `parking_brake`).